### PR TITLE
Update Products.scala to use request.flash

### DIFF
--- a/ch02-your-first-play-application/product-add/app/controllers/Products.scala
+++ b/ch02-your-first-play-application/product-add/app/controllers/Products.scala
@@ -36,8 +36,8 @@ object Products extends Controller {
   }
 
   def newProduct = Action { implicit request =>
-    val form = if (flash.get("error").isDefined)
-      productForm.bind(flash.data)
+    val form = if (request.flash.get("error").isDefined)
+      productForm.bind(request.flash.data)
     else
       productForm
 


### PR DESCRIPTION
Update Products.scala to use request.flash instead of flash, in order to make the code work under Play 2.3.5
